### PR TITLE
add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21' # Wersja Javy - dostosuj do swojego projektu
+          distribution: 'amazon-corretto' # Dystrybucja Javy - dostosuj do swojego projektu
+      - name: Cache Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
+      - name: Install dependencies
+        run: mvn install --quiet
+
+      - name: Run tests
+        run: mvn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run Tests # Nazwa workflow
 
 on:
   push:
@@ -33,3 +33,10 @@ jobs:
 
       - name: Run tests
         run: mvn test
+
+      - name: Save test results
+        if: always() # Wykonuje się zawsze, nawet jeśli testy nie przejdą
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: target/surefire-reports/ # Dostosuj ścieżkę, jeśli wyniki testów są zapisywane gdzie indziej


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the running of tests for the project. The workflow is triggered on push and pull request events to the 'dev' branch. It includes the following steps:

- Checkout the repository
- Set up JDK 21 with the 'amazon-corretto' distribution
- Cache Maven dependencies
- Install project dependencies using 'mvn install'
- Run tests using 'mvn test'
- Save test results as artifacts

This setup ensures that tests are consistently run and results are available for review, improving the reliability and maintainability of the project.